### PR TITLE
一文字の原材料名や食べ物名を登録できるようバリデーションを修正

### DIFF
--- a/apps/backend/src/validation/babyFood.ts
+++ b/apps/backend/src/validation/babyFood.ts
@@ -7,7 +7,10 @@ export const babyFoodNameSchema = z
   .string()
   .min(1, "食べ物名は必須です")
   .max(50, "食べ物名は50文字以内で入力してください")
-  .regex(/^[^\s].*[^\s]$/, "食べ物名の先頭と末尾にスペースは使用できません");
+  .regex(
+    /^[^\s].*[^\s]$|^[^\s]$/,
+    "食べ物名の先頭と末尾にスペースは使用できません"
+  );
 
 /** 評価のバリデーション */
 export const reactionStarsSchema = z

--- a/apps/backend/src/validation/ingredient.ts
+++ b/apps/backend/src/validation/ingredient.ts
@@ -12,7 +12,10 @@ export const ingredientNameSchema = z
   .string()
   .min(1, "原材料名は必須です")
   .max(30, "原材料名は30文字以内で入力してください")
-  .regex(/^[^\s].*[^\s]$/, "原材料名の先頭と末尾にスペースは使用できません");
+  .regex(
+    /^[^\s].*[^\s]$|^[^\s]$/,
+    "原材料名の先頭と末尾にスペースは使用できません"
+  );
 
 /** 原材料作成リクエスト */
 export const IngredientCreateRequestSchema = z.object({


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## 概要
<!-- PRの概要を記載する・Issueの概要の転記でもOK -->
・原材料名や食べ物名を一文字にしようとすると、先頭と末尾にスペースは使用できません、というエラーがでる

## チェック項目
- [x] マージ先のブランチが正しいか
- [x] ローカルで動作確認を行ったか
- [x] 関連するIssueが紐付けされているか
- [x] やったことが記載されているか(他人が見たときに実装・修正内容を把握できるか)
- [x] UIに変更がある場合、スクリーンショットや動画が添付されているか
- [x] Github Copilotのレビューに通っているか(50回/月の利用制限を超えてしまった場合は必須ではない)

## やったこと
<!-- このPRでやったことを記載する -->
- バリデーションを修正して、一文字のものも登録できるようにした

## やらないこと
<!-- このPRではやらないことがあれば記載する -->
- 

## UIのキャプチャ
<!-- UIの変更がある場合はレビュー担当者が分かりやすいようにスクリーンショットや動画を貼る -->
![image](https://github.com/user-attachments/assets/e5989ce6-7004-4787-ae63-55ea235da566)


## ローカルのテストログ
<!-- ローカルでテストを行った際のログがあれば転記する -->
```
```

## 参考
<!-- 実装時に参考にした資料やチームメンバーに共有すべき資料があれば記載する -->
<!-- [資料名](資料のリンク) の形式で記載すること -->
- 

## その他
<!-- その他、共有事項やメモがあれば記載する -->

<!-- I want to review in Japanese. -->
